### PR TITLE
update dependency versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,13 +11,13 @@ categories = ["asynchronous", "algorithms", "concurrency", "data-structures"]
 [dependencies]
 
 [target.'cfg(not(loom))'.dependencies]
-concurrent-queue = "1.2.2"
+concurrent-queue = "2.2.0"
 
 [target.'cfg(not(loom))'.dev-dependencies]
 cobb = "0.0.1"
 
 [target.'cfg(loom)'.dependencies]
-loom = "0.4.1"
+loom = "0.6.1"
 
 [target.'cfg(loom)'.dev-dependencies]
-array-init = "2.0.0"
+array-init = "2.1.0"


### PR DESCRIPTION
`loom` 0.4.1 has a dependency on an old version of generator which is subject to this security advisory:

https://rustsec.org/advisories/RUSTSEC-2020-0151.html

This causes `cargo deny` to report vulnerabilities in projects that use `work-queue`.

Upgrading dependencies to newer versions to eliminate the known vulnerabilities and reduce mixed versions (eg., using both loom 0.4.1 via work-queue and and loom 0.6.1 for newer projcets).